### PR TITLE
force signed 32-bit C enums in bindgen

### DIFF
--- a/rustecal-sys/build.rs
+++ b/rustecal-sys/build.rs
@@ -6,7 +6,7 @@ fn main() {
         return;
     }
     // Prepare bindgen builder, force all enums to 32-bit signed (MSVC ABI)
-+    let mut builder = bindgen::Builder::default()
++   let mut builder = bindgen::Builder::default()
 +       .clang_arg("-fms-compatibility")
         .header("wrapper.h")
         .allowlist_function("eCAL_.*")

--- a/rustecal-sys/build.rs
+++ b/rustecal-sys/build.rs
@@ -5,8 +5,9 @@ fn main() {
         println!("cargo:warning=Skipping bindgen during documentation");
         return;
     }
-    // Prepare bindgen builder
-    let mut builder = bindgen::Builder::default()
+    // Prepare bindgen builder, force all enums to 32-bit signed (MSVC ABI)
++    let mut builder = bindgen::Builder::default()
++       .clang_arg("-fms-compatibility")
         .header("wrapper.h")
         .allowlist_function("eCAL_.*")
         .allowlist_type("eCAL_.*")


### PR DESCRIPTION
On Linux, Clang defaults to the smallest unsigned type for C enums, which
caused bindgen to emit u32 constants that clash with our i32-based Rust
From/Into implementations. Adding the `-fms-compatibility` clang_arg instructs
bindgen to use the MSVC enum ABI (signed 32-bit ints), unifying the enum
representation across platforms and resolving the mismatched type errors.