### PR TITLE
Traits for handling u32 types due to clang enum differences

### DIFF
--- a/rustecal-core/src/core_types/monitoring.rs
+++ b/rustecal-core/src/core_types/monitoring.rs
@@ -142,6 +142,12 @@ impl From<i32> for TransportLayerType {
     }
 }
 
+impl From<u32> for TransportLayerType {
+    fn from(value: u32) -> Self {
+        TransportLayerType::from(value as i32)
+    }
+}
+
 impl From<rustecal_sys::eCAL_Monitoring_STransportLayer> for TransportLayer {
     fn from(raw: rustecal_sys::eCAL_Monitoring_STransportLayer) -> Self {
         Self {

--- a/rustecal-core/src/log_level.rs
+++ b/rustecal-core/src/log_level.rs
@@ -60,8 +60,20 @@ impl From<i32> for LogLevel {
     }
 }
 
+impl From<u32> for LogLevel {
+    fn from(value: u32) -> Self {
+        LogLevel::from(value as i32)
+    }
+}
+
 impl From<LogLevel> for i32 {
     fn from(level: LogLevel) -> Self {
         level as i32
+    }
+}
+
+impl From<LogLevel> for u32 {
+    fn from(level: LogLevel) -> Self {
+        level as u32
     }
 }

--- a/rustecal-service/src/types.rs
+++ b/rustecal-service/src/types.rs
@@ -18,12 +18,18 @@ impl CallState {
 impl From<i32> for CallState {
     fn from(value: i32) -> Self {
         match value {
-            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_none => CallState::None,
-            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_executed => CallState::Executed,
-            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_timeouted => CallState::Timeout,
-            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_failed => CallState::Failed,
+            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_none as i32 => CallState::None,
+            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_executed as i32 => CallState::Executed,
+            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_timeouted as i32 => CallState::Timeout,
+            x if x == rustecal_sys::eCAL_eCallState_eCAL_eCallState_failed as i32 => CallState::Failed,
             other => CallState::Unknown(other),
         }
+    }
+}
+
+impl From<u32> for CallState {
+    fn from(value: u32) -> Self {
+        CallState::from(value as i32)
     }
 }
 


### PR DESCRIPTION
Closes: #40 
Replaces: #41 

Added additional traits for u32 for Linux.  