### PR TITLE
docs: update installation instructions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rust bindings for the high-performance [eCAL](https://github.com/eclipse-ecal/ec
 
 ## System Requirements
 
-This crate requires a native installation of the [Eclipse eCAL](https://github.com/eclipse-ecal/ecal) C/C++ runtime, version 6.0 or newer. General instruction for the installation you can find [here](https://eclipse-ecal.github.io/ecal/stable/getting_started/setup.html).
+This crate requires a native installation of the [Eclipse eCAL](https://github.com/eclipse-ecal/ecal) C/C++ runtime, version 6.0 or newer. General instructions for installation can be found [here](https://eclipse-ecal.github.io/ecal/stable/getting_started/setup.html).
 
 On Linux:
 - Make sure `libecal.so` and headers are available in your system paths.

--- a/docs/src/setup/ecal_installation.md
+++ b/docs/src/setup/ecal_installation.md
@@ -1,6 +1,6 @@
 # eCAL Library Installation
 
-`rustecal` is built on the eCAL v6 API and is not compatible with earlier eCAL v5 releases. General instruction for the installation you can find [here](https://eclipse-ecal.github.io/ecal/stable/getting_started/setup.html).
+`rustecal` is built on the eCAL v6 API and is not compatible with earlier eCAL v5 releases. General instructions for installation can be found [here](https://eclipse-ecal.github.io/ecal/stable/getting_started/setup.html).
 
 ## Windows
 


### PR DESCRIPTION
## Summary
- fix grammar for installation instructions sentence in README
- update the same sentence in docs setup instructions

CODEX TEST
