### PR TITLE
crates rustecal-service and rustecal update (fix in service server drop)

### DIFF
--- a/rustecal-service/Cargo.toml
+++ b/rustecal-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "rustecal-service"
-version       = "0.1.2"
+version       = "0.1.3"
 authors       = ["Rex Schilasky"]
 edition       = "2021"
 description   = "Server/Client API for Eclipse eCAL"

--- a/rustecal/Cargo.toml
+++ b/rustecal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "rustecal"
-version       = "0.1.2"
+version       = "0.1.3"
 edition       = "2021"
 description   = "Meta-crate for rustecal: re-exports core, pubsub and service APIs"
 license       = "Apache-2.0"


### PR DESCRIPTION
### Summary

ServiceServer drops an extra Arc reconstructed from a raw pointer, leading to a second drop of the same allocation.