### PR TITLE
Migrate to Rust Edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "3"
 members = [
     "rustecal",
     "rustecal-core",
@@ -23,5 +24,5 @@ members = [
     "rustecal-samples/pubsub/serde_receive",
     "rustecal-samples/service/mirror_client",
     "rustecal-samples/service/mirror_client_instances",
-    "rustecal-samples/service/mirror_server"
-    ]
+    "rustecal-samples/service/mirror_server",
+]

--- a/rustecal-core/Cargo.toml
+++ b/rustecal-core/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rustecal-core"
 version       = "0.1.6"
 authors       = ["Rex Schilasky"]
-edition       = "2021"
+edition       = "2024"
 description   = "Core API for Eclipse eCAL"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"

--- a/rustecal-core/src/core.rs
+++ b/rustecal-core/src/core.rs
@@ -18,7 +18,7 @@ use std::ptr;
 
 use crate::components::EcalComponents;
 use crate::configuration::Configuration;
-use crate::error::{check, RustecalError};
+use crate::error::{RustecalError, check};
 use crate::types::Version;
 
 /// Provides access to the core initialization, shutdown, and state‑checking functions of eCAL.

--- a/rustecal-pubsub/Cargo.toml
+++ b/rustecal-pubsub/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rustecal-pubsub"
 version       = "0.1.7"
 authors       = ["Rex Schilasky"]
-edition       = "2021"
+edition       = "2024"
 description   = "Publish/Subscribe API for Eclipse eCAL"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"

--- a/rustecal-pubsub/src/payload_writer.rs
+++ b/rustecal-pubsub/src/payload_writer.rs
@@ -33,13 +33,9 @@ thread_local! {
 pub(crate) unsafe extern "C" fn write_full_cb(buffer: *mut c_void, size: usize) -> c_int {
     CURRENT_WRITER.with(|cell| {
         if let Some(writer_ptr) = *cell.borrow() {
-            let writer: &mut dyn PayloadWriter = &mut *writer_ptr;
-            let buf = std::slice::from_raw_parts_mut(buffer as *mut u8, size);
-            if writer.write_full(buf) {
-                0
-            } else {
-                -1
-            }
+            let writer: &mut dyn PayloadWriter = unsafe { &mut *writer_ptr };
+            let buf = unsafe { std::slice::from_raw_parts_mut(buffer as *mut u8, size) };
+            if writer.write_full(buf) { 0 } else { -1 }
         } else {
             -1
         }
@@ -50,13 +46,9 @@ pub(crate) unsafe extern "C" fn write_full_cb(buffer: *mut c_void, size: usize) 
 pub(crate) unsafe extern "C" fn write_mod_cb(buffer: *mut c_void, size: usize) -> c_int {
     CURRENT_WRITER.with(|cell| {
         if let Some(writer_ptr) = *cell.borrow() {
-            let writer: &mut dyn PayloadWriter = &mut *writer_ptr;
-            let buf = std::slice::from_raw_parts_mut(buffer as *mut u8, size);
-            if writer.write_modified(buf) {
-                0
-            } else {
-                -1
-            }
+            let writer: &mut dyn PayloadWriter = unsafe { &mut *writer_ptr };
+            let buf = unsafe { std::slice::from_raw_parts_mut(buffer as *mut u8, size) };
+            if writer.write_modified(buf) { 0 } else { -1 }
         } else {
             -1
         }
@@ -67,7 +59,7 @@ pub(crate) unsafe extern "C" fn write_mod_cb(buffer: *mut c_void, size: usize) -
 pub(crate) unsafe extern "C" fn get_size_cb() -> usize {
     CURRENT_WRITER.with(|cell| {
         if let Some(writer_ptr) = *cell.borrow() {
-            let writer: &mut dyn PayloadWriter = &mut *writer_ptr;
+            let writer: &mut dyn PayloadWriter = unsafe { &mut *writer_ptr };
             writer.get_size()
         } else {
             0

--- a/rustecal-pubsub/src/publisher.rs
+++ b/rustecal-pubsub/src/publisher.rs
@@ -1,5 +1,5 @@
 use crate::payload_writer::{
-    get_size_cb, write_full_cb, write_mod_cb, PayloadWriter, CURRENT_WRITER,
+    CURRENT_WRITER, PayloadWriter, get_size_cb, write_full_cb, write_mod_cb,
 };
 use crate::types::TopicId;
 use rustecal_core::types::DataTypeInfo;

--- a/rustecal-pubsub/src/typed_subscriber.rs
+++ b/rustecal-pubsub/src/typed_subscriber.rs
@@ -3,7 +3,7 @@ use crate::types::TopicId;
 use rustecal_core::types::DataTypeInfo;
 use rustecal_sys::{eCAL_SDataTypeInformation, eCAL_SReceiveCallbackData, eCAL_STopicId};
 use std::{
-    ffi::{c_void, CStr},
+    ffi::{CStr, c_void},
     marker::PhantomData,
     slice,
 };

--- a/rustecal-samples/benchmarks/performance_receive/Cargo.toml
+++ b/rustecal-samples/benchmarks/performance_receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "performance_receive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }

--- a/rustecal-samples/benchmarks/performance_receive/src/main.rs
+++ b/rustecal-samples/benchmarks/performance_receive/src/main.rs
@@ -6,7 +6,7 @@ use rustecal::{Ecal, EcalComponents, TypedSubscriber};
 use rustecal_types_bytes::BytesMessage;
 use std::thread::sleep;
 use std::{
-    sync::{atomic::Ordering, Arc, Mutex},
+    sync::{Arc, Mutex, atomic::Ordering},
     thread,
     time::{Duration, Instant},
 };

--- a/rustecal-samples/benchmarks/performance_send/Cargo.toml
+++ b/rustecal-samples/benchmarks/performance_send/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "performance_send"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }

--- a/rustecal-samples/monitoring/logging_receive/Cargo.toml
+++ b/rustecal-samples/monitoring/logging_receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "logging_receive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal"}

--- a/rustecal-samples/monitoring/monitoring_receive/Cargo.toml
+++ b/rustecal-samples/monitoring/monitoring_receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "monitoring_receive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal"}

--- a/rustecal-samples/pubsub/blob_receive/Cargo.toml
+++ b/rustecal-samples/pubsub/blob_receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blob_receive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }

--- a/rustecal-samples/pubsub/blob_send/Cargo.toml
+++ b/rustecal-samples/pubsub/blob_send/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "blob_send"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }

--- a/rustecal-samples/pubsub/hello_receive/Cargo.toml
+++ b/rustecal-samples/pubsub/hello_receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello_receive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }

--- a/rustecal-samples/pubsub/hello_send/Cargo.toml
+++ b/rustecal-samples/pubsub/hello_send/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello_send"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }

--- a/rustecal-samples/pubsub/person_receive/Cargo.toml
+++ b/rustecal-samples/pubsub/person_receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "person_receive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [dependencies]

--- a/rustecal-samples/pubsub/person_receive/Cargo.toml
+++ b/rustecal-samples/pubsub/person_receive/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-prost = "0.13.5"
+prost = "0.14"
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }
 rustecal-types-protobuf = { path = "../../../rustecal-types-protobuf" }
 
 [build-dependencies]
-prost-build = "0.13.5"
+prost-build = "0.14"

--- a/rustecal-samples/pubsub/person_send/Cargo.toml
+++ b/rustecal-samples/pubsub/person_send/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "person_send"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [dependencies]

--- a/rustecal-samples/pubsub/person_send/Cargo.toml
+++ b/rustecal-samples/pubsub/person_send/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-prost = "0.13.5"
+prost = "0.14"
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }
 rustecal-types-protobuf = { path = "../../../rustecal-types-protobuf" }
 
 [build-dependencies]
-prost-build = "0.13.5"
+prost-build = "0.14"

--- a/rustecal-samples/pubsub/serde_receive/Cargo.toml
+++ b/rustecal-samples/pubsub/serde_receive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "serde_receive"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/rustecal-samples/pubsub/serde_send/Cargo.toml
+++ b/rustecal-samples/pubsub/serde_send/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "serde_send"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/rustecal-samples/service/mirror_client/Cargo.toml
+++ b/rustecal-samples/service/mirror_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mirror_client"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["service"] }

--- a/rustecal-samples/service/mirror_client_instances/Cargo.toml
+++ b/rustecal-samples/service/mirror_client_instances/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mirror_client_instances"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["service"] }

--- a/rustecal-samples/service/mirror_server/Cargo.toml
+++ b/rustecal-samples/service/mirror_server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mirror_server"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rustecal = { path = "../../../rustecal", features = ["service"] }

--- a/rustecal-service/Cargo.toml
+++ b/rustecal-service/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rustecal-service"
 version       = "0.1.5"
 authors       = ["Rex Schilasky"]
-edition       = "2021"
+edition       = "2024"
 description   = "Server/Client API for Eclipse eCAL"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"

--- a/rustecal-sys/Cargo.toml
+++ b/rustecal-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rustecal-sys"
 version       = "0.1.4"
 authors       = ["Rex Schilasky"]
-edition       = "2021"
+edition       = "2024"
 build         = "build.rs"
 description   = "Raw FFI bindings to Eclipse eCAL C API"
 license       = "Apache-2.0"

--- a/rustecal-sys/Cargo.toml
+++ b/rustecal-sys/Cargo.toml
@@ -13,7 +13,7 @@ keywords      = ["ecal", "ipc", "pubsub", "server-client", "middleware"]
 categories    = ["network-programming", "api-bindings"]
 
 [build-dependencies]
-bindgen       = "0.71"
+bindgen       = "0.72"
 
 [features]
 default = ["dynamic"]

--- a/rustecal-types-bytes/Cargo.toml
+++ b/rustecal-types-bytes/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rustecal-types-bytes"
 version       = "0.1.6"
 authors       = ["Rex Schilasky"]
-edition       = "2021"
+edition       = "2024"
 description   = "Vec<u8> type support for rustecal TypedPublisher/TypedSubscriber"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"

--- a/rustecal-types-protobuf/Cargo.toml
+++ b/rustecal-types-protobuf/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rustecal-types-protobuf"
 version       = "0.1.4"
 authors       = ["Rex Schilasky"]
-edition       = "2021"
+edition       = "2024"
 description   = "Google Protobuf type support for rustecal TypedPublisher/TypedSubscriber"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"

--- a/rustecal-types-protobuf/Cargo.toml
+++ b/rustecal-types-protobuf/Cargo.toml
@@ -12,6 +12,6 @@ keywords      = ["ecal", "ipc", "pubsub", "message-support", "middleware"]
 categories    = ["network-programming", "api-bindings"]
 
 [dependencies]
-prost           = "0.13"
+prost           = "0.14"
 rustecal-core   = { version = "0.1", path = "../rustecal-core" }
 rustecal-pubsub = { version = "0.1", path = "../rustecal-pubsub" }

--- a/rustecal-types-serde/Cargo.toml
+++ b/rustecal-types-serde/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "rustecal-types-serde"
 version       = "0.1.4"
-edition       = "2021"
+edition       = "2024"
 description   = "JSON/CBOR/MessagePack type support for rustecal TypedPublisher/TypedSubscriber"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"

--- a/rustecal-types-serde/src/cbor_message.rs
+++ b/rustecal-types-serde/src/cbor_message.rs
@@ -1,4 +1,4 @@
-use crate::format_support::{short_type_name, FormatSupport};
+use crate::format_support::{FormatSupport, short_type_name};
 use crate::make_format;
 use rustecal_core::types::DataTypeInfo;
 use rustecal_pubsub::typed_publisher::PublisherMessage;

--- a/rustecal-types-serde/src/json_message.rs
+++ b/rustecal-types-serde/src/json_message.rs
@@ -1,4 +1,4 @@
-use crate::format_support::{short_type_name, FormatSupport};
+use crate::format_support::{FormatSupport, short_type_name};
 use crate::make_format;
 use rustecal_core::types::DataTypeInfo;
 use rustecal_pubsub::typed_publisher::PublisherMessage;

--- a/rustecal-types-serde/src/msgpack_message.rs
+++ b/rustecal-types-serde/src/msgpack_message.rs
@@ -1,4 +1,4 @@
-use crate::format_support::{short_type_name, FormatSupport};
+use crate::format_support::{FormatSupport, short_type_name};
 use crate::make_format;
 use rustecal_core::types::DataTypeInfo;
 use rustecal_pubsub::typed_publisher::PublisherMessage;

--- a/rustecal-types-string/Cargo.toml
+++ b/rustecal-types-string/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "rustecal-types-string"
 version       = "0.1.4"
 authors       = ["Rex Schilasky"]
-edition       = "2021"
+edition       = "2024"
 description   = "String type support for rustecal TypedPublisher/TypedSubscriber"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"

--- a/rustecal/Cargo.toml
+++ b/rustecal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "rustecal"
 version       = "0.1.6"
-edition       = "2021"
+edition       = "2024"
 description   = "Meta-crate for rustecal: re-exports core, pubsub and service APIs"
 license       = "Apache-2.0"
 repository    = "https://github.com/eclipse-ecal/rustecal"


### PR DESCRIPTION
### Summary

This PR updates the project to Rust Edition 2024 and Resolver Version 3.
While updating the dependencies, I chose not to specify the patch version for `prost` (`0.14` instead of `0.14.1`) since it never seemed to be specified for other dependencies. Please let me know if this was not your intention.
Rust Edition 2024 requires the explicit use of unsafe blocks in the `unsafe extern "C"` functions. For now, I have used the blocks in a way that gives them minimal scope. Of course, we could also wrap the entire function bodies in `unsafe` blocks. Let me know what you prefer.

### Checklist

- [x] I have tested this change locally
- [ ] I have documented any public APIs or CLI changes
- [ ] I have added appropriate examples or comments
- [x] The code builds and passes all checks (`cargo check`, `cargo test`)
- [ ] I have updated the changelog if applicable
