### PR TITLE
Fix selecting latest eCAL version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,7 +18,9 @@ RUN set -eux; \
     # Replace the placeholder with the actual eCAL version
     if [ "$ECAL_VER" = "auto" ]; then \
         ECAL_VER=$(curl -sSL https://api.github.com/repos/eclipse-ecal/ecal/releases \
-                  | jq -r '[.[] | .tag_name][0]'); \
+            | jq -r '.[] | select((.draft|not) and (.prerelease|not)) | .tag_name' \
+            | sort -V \
+            | tail -n1); \
     fi; \
     # Locate the .deb that matches the tag and Ubuntu 22.04
     DEB_URL=$(curl -sSL https://api.github.com/repos/eclipse-ecal/ecal/releases/tags/${ECAL_VER} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
           # Replace the placeholder with the actual eCAL version
           if [ -z "$ECAL_VER" ] || [ "$ECAL_VER" = "auto" ]; then \
             ECAL_VER=$(curl -sSL https://api.github.com/repos/eclipse-ecal/ecal/releases \
-              | jq -r '[.[] | .tag_name][0]'); \
+            | jq -r '.[] | select((.draft|not) and (.prerelease|not)) | .tag_name' \
+            | sort -V \
+            | tail -n1); \
           fi; \
           # Locate the .deb that matches the tag and Ubuntu 22.04
           DEB_URL=$(curl -sSL https://api.github.com/repos/eclipse-ecal/ecal/releases/tags/${ECAL_VER} \


### PR DESCRIPTION
### Summary

As mentioned in #76, the current approach of selecting the latest eCAL release does not handle old versions receiving maintenance patches well.
This PR adjusts the approach so that it sorts the releases by name rather than simply selecting the latest release. However, this approach does not work well with pre-releases and would require further development. Since eCAL 6.0.0 has been released, I have decided to ignore drafts and re-releases altogether. They can still be selected manually. Please let me know if you are fine with this or if you would still like the devcontainer and workflow to select the latest releases, including pre-releases and drafts.

### Checklist

- [x] I have tested this change locally
- [ ] I have documented any public APIs or CLI changes
- [ ] I have added appropriate examples or comments
- [x] The code builds and passes all checks (`cargo check`, `cargo test`)
- [ ] I have updated the changelog if applicable
