### PR TITLE
Improve Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     name: ${{ matrix.task.name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install mdBook
         uses: taiki-e/install-action@v2
@@ -22,7 +22,7 @@ jobs:
         run: mdbook build docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -26,6 +26,7 @@ jobs:
         run: mdbook build docs
 
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   doc:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
### Summary

I've noticed that the _Generate API Documentation_ workflow always fails on PRs since they are not allowed to access the `GITHUB_TOKEN`. PRs should only build new docs for testing purposes, not publish them.
While at it, I also updated some dependencies and specified [permissions](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#getting-started) and [concurrency](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency) explicitly in the `generate-docs.yml`.

In the future, it may also be worth looking into the official [`upload-pages-artifact` and `deploy-pages`](https://docs.github.com/en/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages#linking-separate-build-and-deploy-jobs) actions.

I hope this works as intended, as it was difficult to test locally.

### Checklist

- [ ] I have tested this change locally
- [ ] I have documented any public APIs or CLI changes
- [ ] I have added appropriate examples or comments
- [x] The code builds and passes all checks (`cargo check`, `cargo test`)
- [ ] I have updated the changelog if applicable
