### PR TITLE
Added protobuf descriptor support

### DIFF
--- a/rustecal-samples/pubsub/person_receive/Cargo.toml
+++ b/rustecal-samples/pubsub/person_receive/Cargo.toml
@@ -6,8 +6,10 @@ build = "build.rs"
 
 [dependencies]
 prost = "0.14"
+prost-reflect = { version = "0.16.0", features = ["derive"] }
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }
 rustecal-types-protobuf = { path = "../../../rustecal-types-protobuf" }
 
 [build-dependencies]
 prost-build = "0.14"
+prost-reflect-build = "0.16.0"

--- a/rustecal-samples/pubsub/person_receive/build.rs
+++ b/rustecal-samples/pubsub/person_receive/build.rs
@@ -1,11 +1,16 @@
 fn main() {
-    prost_build::compile_protos(
-        &[
-            "proto/person.proto",
-            "proto/animal.proto",
-            "proto/house.proto",
-        ],
-        &["proto"],
-    )
-    .unwrap();
+    let protos = [
+        "proto/person.proto",
+        "proto/animal.proto",
+        "proto/house.proto",
+    ];
+
+    let protos_inc = ["proto"];
+
+    prost_build::compile_protos(&protos, &protos_inc).unwrap();
+
+    prost_reflect_build::Builder::new()
+        .descriptor_pool("crate::DESCRIPTOR_POOL")
+        .compile_protos(&protos, &protos_inc)
+        .unwrap();
 }

--- a/rustecal-samples/pubsub/person_receive/src/main.rs
+++ b/rustecal-samples/pubsub/person_receive/src/main.rs
@@ -12,6 +12,16 @@ mod environment {
     include!(concat!(env!("OUT_DIR"), "/pb.environment.rs"));
 }
 
+use prost_reflect::DescriptorPool;
+use std::sync::LazyLock;
+
+static DESCRIPTOR_POOL: LazyLock<DescriptorPool> = LazyLock::new(|| {
+    DescriptorPool::decode(
+        include_bytes!(concat!(env!("OUT_DIR"), "/file_descriptor_set.bin")).as_ref(),
+    )
+    .unwrap()
+});
+
 use people::Person;
 impl IsProtobufType for Person {}
 

--- a/rustecal-samples/pubsub/person_send/Cargo.toml
+++ b/rustecal-samples/pubsub/person_send/Cargo.toml
@@ -6,8 +6,10 @@ build = "build.rs"
 
 [dependencies]
 prost = "0.14"
+prost-reflect = { version = "0.16.0", features = ["derive"] }
 rustecal = { path = "../../../rustecal", features = ["pubsub"] }
 rustecal-types-protobuf = { path = "../../../rustecal-types-protobuf" }
 
 [build-dependencies]
 prost-build = "0.14"
+prost-reflect-build = "0.16.0"

--- a/rustecal-samples/pubsub/person_send/build.rs
+++ b/rustecal-samples/pubsub/person_send/build.rs
@@ -1,11 +1,16 @@
 fn main() {
-    prost_build::compile_protos(
-        &[
-            "proto/person.proto",
-            "proto/animal.proto",
-            "proto/house.proto",
-        ],
-        &["proto"],
-    )
-    .unwrap();
+    let protos = [
+        "proto/person.proto",
+        "proto/animal.proto",
+        "proto/house.proto",
+    ];
+
+    let protos_inc = ["proto"];
+
+    prost_build::compile_protos(&protos, &protos_inc).unwrap();
+
+    prost_reflect_build::Builder::new()
+        .descriptor_pool("crate::DESCRIPTOR_POOL")
+        .compile_protos(&protos, &protos_inc)
+        .unwrap();
 }

--- a/rustecal-samples/pubsub/person_send/src/main.rs
+++ b/rustecal-samples/pubsub/person_send/src/main.rs
@@ -11,6 +11,16 @@ mod environment {
     include!(concat!(env!("OUT_DIR"), "/pb.environment.rs"));
 }
 
+use prost_reflect::DescriptorPool;
+use std::sync::LazyLock;
+
+static DESCRIPTOR_POOL: LazyLock<DescriptorPool> = LazyLock::new(|| {
+    DescriptorPool::decode(
+        include_bytes!(concat!(env!("OUT_DIR"), "/file_descriptor_set.bin")).as_ref(),
+    )
+    .unwrap()
+});
+
 use people::Person;
 use rustecal::pubsub::publisher::Timestamp;
 

--- a/rustecal-service/src/lib.rs
+++ b/rustecal-service/src/lib.rs
@@ -7,11 +7,11 @@
 //! - `ServiceServer`: host services, handle requests with callbacks.
 //!
 //! ## Example
-//! ```rust
+//! '''rust
 //! use rustecal_service::ServiceClient;
 //! let client = ServiceClient::new("mirror_service").unwrap();
 //! let response = client.call("Hello!".as_bytes(), std::time::Duration::from_millis(500));
-//! ```
+//! '''
 
 pub mod client;
 pub mod client_instance;

--- a/rustecal-types-protobuf/Cargo.toml
+++ b/rustecal-types-protobuf/Cargo.toml
@@ -12,6 +12,7 @@ keywords      = ["ecal", "ipc", "pubsub", "message-support", "middleware"]
 categories    = ["network-programming", "api-bindings"]
 
 [dependencies]
-prost           = "0.14"
+prost = "0.14"
+prost-reflect = { version = "0.16.0", features = ["derive"] }
 rustecal-core   = { version = "0.1", path = "../rustecal-core" }
 rustecal-pubsub = { version = "0.1", path = "../rustecal-pubsub" }

--- a/rustecal/src/lib.rs
+++ b/rustecal/src/lib.rs
@@ -9,14 +9,14 @@
 //! - `service`: Synchronous RPC communication.
 //!
 //! ## Example
-//! ```rust
+//! '''rust
 //! use rustecal::{Ecal, TypedPublisher};
 //! use rustecal_types_string::StringMessage;
 //!
 //! Ecal::initialize(Some("example node"), EcalComponents::DEFAULT, None).unwrap();
-//! let pub_ = TypedPublisher::<StringMessage>::new("hello topic").unwrap();
+//! let pub_ = `TypedPublisher::<StringMessage>::new`("hello topic").unwrap();
 //! pub_.send(&StringMessage{data: "Hello!".into()}, Timestamp::Auto);
-//! ```
+//! '''
 //!
 
 // —————————————————————————————————————————————————————————————————————————————


### PR DESCRIPTION
Added protobuf descriptor support
Fixed cargo tests

### Summary

Adds reflection to protobuf publishers to populate the descriptor field of DataTypeInfo so it is viewable in ecal_mon_gui

### Related Issues / Discussions

Closes #80 

### Checklist

- [x] I have tested this change locally
- [ ] I have documented any public APIs or CLI changes
- [ ] I have added appropriate examples or comments
- [x] The code builds and passes all checks (`cargo check`, `cargo test`)
- [ ] I have updated the changelog if applicable

### Screenshots / Output (if applicable)

Run `cargo run --bin person_send`

<img width="1920" height="1200" alt="Screenshot from 2025-08-25 13-27-15" src="https://github.com/user-attachments/assets/e2af6ffe-dcfe-4f79-a643-2f752b367859" />

