### PR TITLE
Send a subset of protobuf descriptors

### DIFF
--- a/rustecal-types-protobuf/src/lib.rs
+++ b/rustecal-types-protobuf/src/lib.rs
@@ -3,7 +3,7 @@
 //! Provides support for Protobuf message serialization with rustecal.
 
 use prost::Message;
-use prost_reflect::ReflectMessage;
+use prost_reflect::{FileDescriptor, ReflectMessage};
 use rustecal_core::types::DataTypeInfo;
 use rustecal_pubsub::typed_publisher::PublisherMessage;
 use rustecal_pubsub::typed_subscriber::SubscriberMessage;
@@ -34,14 +34,49 @@ where
     /// This includes:
     /// - `proto` as encoding
     /// - the Rust type name
-    /// - an optional descriptor (currently empty)
+    /// - an optional descriptor
     fn datatype() -> DataTypeInfo {
         let default_instance = T::default();
+        let instance_descriptor = default_instance.descriptor();
+        let type_name = instance_descriptor.full_name().to_string();
+
+        let mut descriptor_pool = prost_reflect::DescriptorPool::new();
+
+        // List of proto files for a specific protobuf message type
+        let mut proto_filenames = instance_descriptor
+            .parent_file_descriptor_proto()
+            .dependency
+            .clone();
+        // Add the main proto message file
+        proto_filenames.push(
+            instance_descriptor
+                .parent_file_descriptor_proto()
+                .name()
+                .to_string(),
+        );
+
+        // Filter the pool to the set of file decriptors needed
+        let file_descriptors: Vec<FileDescriptor> = instance_descriptor
+            .parent_pool()
+            .files()
+            .filter(|s| proto_filenames.contains(&s.name().to_string()))
+            .collect();
+
+        for proto_file in file_descriptors.iter() {
+            let mut file_descriptor_proto = proto_file.file_descriptor_proto().clone();
+            // Remove the source_code_info from the descriptor which add excess comments
+            // from original proto to the descriptor message that aren't needed
+            file_descriptor_proto.source_code_info = None;
+
+            descriptor_pool
+                .add_file_descriptor_proto(file_descriptor_proto)
+                .unwrap();
+        }
 
         DataTypeInfo {
             encoding: "proto".to_string(),
-            type_name: default_instance.descriptor().full_name().to_string(),
-            descriptor: default_instance.descriptor().parent_pool().encode_to_vec(), // descriptor injection planned
+            type_name,
+            descriptor: descriptor_pool.encode_to_vec(),
         }
     }
 
@@ -61,7 +96,8 @@ impl<T> PublisherMessage for ProtobufMessage<T>
 where
     T: Message + Default + IsProtobufType + ReflectMessage,
 {
-    /// Returns the same datatype information as [`SubscriberMessage`] implementation.
+    /// Returns the same datatype information as [`SubscriberMessage`]
+    /// implementation.
     fn datatype() -> DataTypeInfo {
         <ProtobufMessage<T> as SubscriberMessage>::datatype()
     }
@@ -69,7 +105,8 @@ where
     /// Encodes the message to a byte buffer.
     ///
     /// # Panics
-    /// Will panic if `prost::Message::encode` fails (should never panic for valid messages).
+    /// Will panic if `prost::Message::encode` fails (should never panic for
+    /// valid messages).
     fn to_bytes(&self) -> Arc<[u8]> {
         let mut buf = Vec::with_capacity(self.data.encoded_len());
         self.data


### PR DESCRIPTION
### Summary

Updates the protobuf descriptor to send only the subset of descriptors needed to describe a given protobuf publisher message.

I had a internal crate that had a large number of protobuf message definitions all under the same protobuf package.  My naive initial implementation would send the entire descriptor pool of every message for every publisher 😬.  Besides being overly verbose it would confuse ecal_mon_gui when trying to parse the messages.

There was also a large amount of comments from the original .proto (prost_types::FileDescriptorProto::source_code_info) that was being send along with the descriptor which is not needed.  Also the documentation states it can be removed. https://docs.rs/prost-types/latest/prost_types/struct.FileDescriptorProto.html#structfield.source_code_info Now the descriptor more closely aligns to the form of C++ ecal_sample_person_send.  

### Related Issues / Discussions

Related to #80 

### Checklist

- [x] I have tested this change locally
- [ ] I have documented any public APIs or CLI changes
- [x] I have added appropriate examples or comments
- [x] The code builds and passes all checks (`cargo check`, `cargo test`)
- [ ] I have updated the changelog if applicable
