### PR TITLE
CI: Fail `clippy` on warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         task:
           - {
               name: clippy,
-              cmd: "clippy --workspace --all-targets --all-features --tests --examples",
+              cmd: "clippy --workspace --all-targets --all-features --tests --examples -- -D warnings",
             }
           - { name: fmt, cmd: "fmt --all -- --check" }
           - {


### PR DESCRIPTION
### Summary

The CI setup I introduced in #72 did not enforce `clippy` warnings as errors. This PR fixes that by adding `-D warnings` so that CI fails if `clippy` emits any warnings.

### Related Issues / Discussions

Related to #72.

### Checklist

- [x] I have tested this change locally
- [ ] I have documented any public APIs or CLI changes
- [ ] I have added appropriate examples or comments
- [x] The code builds and passes all checks (`cargo check`, `cargo test`)
- [ ] I have updated the changelog if applicable

